### PR TITLE
fix:更换时间戳API地址

### DIFF
--- a/changebushu.py
+++ b/changebushu.py
@@ -94,7 +94,7 @@ def main():
     return result
  
 def get_time():
-    url = 'http://api.m.taobao.com/rest/api3.do?api=mtop.common.getTimestamp'
+    url = 'https://acs.m.taobao.com/gw/mtop.common.getTimestamp/'
     response = requests.get(url, headers=headers).json()
     t = response['data']['t']
     return t

--- a/changebushu.py
+++ b/changebushu.py
@@ -1,4 +1,6 @@
-import requests, time, re, json, os
+import requests
+import time
+import re
 from random import randint
  
 headers = {

--- a/changebushu_Action.py
+++ b/changebushu_Action.py
@@ -85,7 +85,7 @@ def main():
  
 
 def get_time():
-    url = 'http://api.m.taobao.com/rest/api3.do?api=mtop.common.getTimestamp'
+    url = 'https://acs.m.taobao.com/gw/mtop.common.getTimestamp/'
     response = requests.get(url, headers=headers).json()
     t = response['data']['t']
     return t

--- a/changebushu_Action.py
+++ b/changebushu_Action.py
@@ -1,4 +1,7 @@
-import requests, time, re, json, os
+import requests
+import time
+import re
+import os
 from random import randint
  
 headers = {


### PR DESCRIPTION
由于原API已失效

将API地址更换为
`https://acs.m.taobao.com/gw/mtop.common.getTimestamp/`